### PR TITLE
Add basic support for configuring server password

### DIFF
--- a/browser/irc.ts
+++ b/browser/irc.ts
@@ -20,6 +20,7 @@ export function connect(data: IConnectionData, ipc: Ipc) {
     port: data.port,
     encoding: data.encoding,
     autoConnect: false,
+    password: data.password,
   });
 
   client.connect();

--- a/lib.d/koko/koko.d.ts
+++ b/lib.d/koko/koko.d.ts
@@ -15,6 +15,7 @@ interface IConnectionData {
   host: string;
   nick: string;
   username: string;
+  password: string;
   realname: string;
   port: string;
   encoding: string;
@@ -56,6 +57,7 @@ interface IModifierState {
 interface IServerInterface {
   nick?: string;
   username?: string;
+  password: string;
   realname?: string;
   name: string;
   host: string;

--- a/lib.d/koko/koko.d.ts
+++ b/lib.d/koko/koko.d.ts
@@ -57,7 +57,7 @@ interface IModifierState {
 interface IServerInterface {
   nick?: string;
   username?: string;
-  password: string;
+  password?: string;
   realname?: string;
   name: string;
   host: string;

--- a/lib.d/koko/koko.d.ts
+++ b/lib.d/koko/koko.d.ts
@@ -64,3 +64,9 @@ interface IServerInterface {
   port?: string;
   encoding?: string;
 }
+
+interface IServerFormField {
+    label: string,
+    inputName: string,
+    inputType?: string
+}

--- a/renderer/server-form.tsx
+++ b/renderer/server-form.tsx
@@ -34,7 +34,7 @@ class ServerForm extends ReactComponent<ServerFormProps, {}> {
   }
 
   applyValues() {
-    let fields = ['host', 'port', 'encoding', 'nick', 'username', 'realname'];
+    let fields = ['host', 'port', 'encoding', 'nick', 'username', 'password', 'realname'];
     fields.forEach(fieldName => {
       React.findDOMNode<HTMLInputElement>(this.refs[fieldName]).value = this.val(fieldName);
     });
@@ -70,6 +70,7 @@ class ServerForm extends ReactComponent<ServerFormProps, {}> {
               {label: 'Encoding', inputName: 'encoding'},
               {label: 'Nick', inputName: 'nick'},
               {label: 'Username', inputName: 'username'},
+              {label: 'Password', inputName: 'password'},
               {label: 'Real Name', inputName: 'realname'},
             ].map(field => this.field(field.label, field.inputName))}
             <button>Connect</button>

--- a/renderer/server-form.tsx
+++ b/renderer/server-form.tsx
@@ -81,10 +81,11 @@ class ServerForm extends ReactComponent<ServerFormProps, {}> {
   }
 
   field(label: string, inputName: string): React.ReactElement<any> {
+    let inputType = inputName == 'password' ? 'password' : 'text';
     return (
       <div>
         <div className='field-name'>{label}</div>
-        <input type='text' name={inputName} ref={inputName} />
+        <input type={inputType} name={inputName} ref={inputName} />
       </div>
     );
   }

--- a/renderer/server-form.tsx
+++ b/renderer/server-form.tsx
@@ -70,9 +70,10 @@ class ServerForm extends ReactComponent<ServerFormProps, {}> {
               {label: 'Encoding', inputName: 'encoding'},
               {label: 'Nick', inputName: 'nick'},
               {label: 'Username', inputName: 'username'},
-              {label: 'Password', inputName: 'password'},
+              {label: 'Password', inputName: 'password', inputType: 'password'},
               {label: 'Real Name', inputName: 'realname'},
-            ].map(field => this.field(field.label, field.inputName))}
+            ].map((field: IServerFormField) =>
+              this.field(field.label, field.inputName, field.inputType))}
             <button>Connect</button>
           </form>
         </div>
@@ -80,8 +81,7 @@ class ServerForm extends ReactComponent<ServerFormProps, {}> {
     );
   }
 
-  field(label: string, inputName: string): React.ReactElement<any> {
-    let inputType = inputName == 'password' ? 'password' : 'text';
+  field(label: string, inputName: string, inputType: string = 'text'): React.ReactElement<any> {
     return (
       <div>
         <div className='field-name'>{label}</div>


### PR DESCRIPTION
This diff adds basic support for configuring password, in case you need to auth to the server or a bouncer.

It works correctly for authorizing to my bouncer, and doesn't throw any more warnings than current master after `make build` and `make run`. One problem however, is that I haven't been able to figure out how to do password masking. I can add that in another request or this one if you feel that it's blocking. (This is the first React app I've looked at, so I'd be grateful for some pointers about how to do that.)